### PR TITLE
feat: 게임eat: 게임·스테이지 로직 전반을 RPC 기반으로 리팩터링 및 동기화 처리

### DIFF
--- a/Assets/Workspace/Lee_yerin/Scenes/Room_Test_Scene.unity
+++ b/Assets/Workspace/Lee_yerin/Scenes/Room_Test_Scene.unity
@@ -449,6 +449,7 @@ GameObject:
   m_Component:
   - component: {fileID: 759923964}
   - component: {fileID: 759923966}
+  - component: {fileID: 759923967}
   m_Layer: 0
   m_Name: ==[Game Manager]==
   m_TagString: Untagged
@@ -490,6 +491,25 @@ MonoBehaviour:
   - {fileID: 1029047546}
   selectedStages: []
   ongoingStage: -1
+--- !u!114 &759923967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759923963}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SortKey: 3160376765
+  ObjectInterest: 1
+  Flags: 262145
+  NestedObjects: []
+  NetworkedBehaviours:
+  - {fileID: 759923966}
+  ForceRemoteRenderTimeframe: 0
 --- !u!1 &844762418
 GameObject:
   m_ObjectHideFlags: 0
@@ -678,7 +698,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
@@ -696,6 +716,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 844762419}
+  - {fileID: 1890121832}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1001,6 +1022,140 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1564413385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1564413386}
+  - component: {fileID: 1564413388}
+  - component: {fileID: 1564413387}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1564413386
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1564413385}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1890121832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1564413387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1564413385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Logic Start
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 100
+  m_fontSizeBase: 100
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1564413388
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1564413385}
+  m_CullTransparentMesh: 1
 --- !u!1 &1719807575
 GameObject:
   m_ObjectHideFlags: 0
@@ -1376,6 +1531,139 @@ MonoBehaviour:
   Components:
   - {fileID: 1870849581}
   _guid: 91d1482c-d93c-4dd7-
+--- !u!1 &1890121831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1890121832}
+  - component: {fileID: 1890121835}
+  - component: {fileID: 1890121834}
+  - component: {fileID: 1890121833}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1890121832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1890121831}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1564413386}
+  m_Father: {fileID: 878013269}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -250, y: 0}
+  m_SizeDelta: {x: 500, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1890121833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1890121831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1890121834}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 759923966}
+        m_TargetAssemblyTypeName: GameManager, Assembly-CSharp
+        m_MethodName: InitializeStagesAndStart
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1890121834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1890121831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1890121835
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1890121831}
+  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/Lee_yerin/Scenes/Room_Test_Scene.unity
+++ b/Assets/Workspace/Lee_yerin/Scenes/Room_Test_Scene.unity
@@ -241,6 +241,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 759923966}
   stageTime: 10
   alivePlayers:
   - {fileID: 0}
@@ -365,6 +366,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 759923966}
   stageTime: 10
   alivePlayers:
   - {fileID: 0}
@@ -842,6 +844,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 759923966}
   stageTime: 10
   alivePlayers:
   - {fileID: 0}
@@ -966,6 +969,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 759923966}
   stageTime: 10
   alivePlayers:
   - {fileID: 0}

--- a/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
@@ -11,11 +11,6 @@ using UnityEngine.SceneManagement;
 /// </summary>
 public class GameManager : NetworkBehaviour
 {
-    #region Singleton
-    static GameManager instance;    // 싱글톤 인스턴스
-    public static GameManager Instance => instance;
-    #endregion
-
     #region Variables
     //TODO... Fusion 연결 후 룸 안에 있는 플레이어 받아와 저장
     [SerializeField] List<StageManager> selectableStages; // 선택 가능한 스테이지 목록
@@ -26,17 +21,6 @@ public class GameManager : NetworkBehaviour
     #endregion
 
     #region Unity Event
-    private void Awake()
-    {
-        // 싱글톤 패턴 적용
-        if (instance == null)
-        {
-            instance = this;
-            DontDestroyOnLoad(gameObject);  // 씬이 변경되어도 삭제되지 않도록 설정
-        }
-        else
-            Destroy(gameObject);    // 중복 생성 방지
-    }
     #endregion
 
     #region Game Logic
@@ -46,8 +30,19 @@ public class GameManager : NetworkBehaviour
     [ContextMenu("InitializeStagesAndStart")]
     public void InitializeStagesAndStart()
     {
-        SelectRandomUniqueStage();  // 랜덤으로 스테이지 선택
-        MoveNextStage();    // 첫 번째 스테이지로 이동
+        Debug.Log("InitializeStagesAndStart");
+
+        if (Runner == null)
+            Debug.Log("Runner is Null");
+        else
+            Debug.Log(Runner.gameObject.name);
+
+        if (Runner.IsServer && HasStateAuthority)
+        {
+            Debug.Log("HasStateAuthority");
+            SelectRandomUniqueStage();  // 랜덤으로 스테이지 선택
+        }
+        //MoveNextStage();            // 첫 번째 스테이지로 이동
     }
 
     /// <summary>
@@ -66,6 +61,8 @@ public class GameManager : NetworkBehaviour
             return;
         }
 
+        int[] chosenStages = new int[MIN_STAGE_COUNT];
+
         for (int i = 0; i < MIN_STAGE_COUNT; i++)
         {
             int stageNum = Random.Range(0, selectableStages.Count);
@@ -74,8 +71,18 @@ public class GameManager : NetworkBehaviour
             while (selectedStages.Contains(selectableStages[stageNum]))
                 stageNum = Random.Range(0, selectableStages.Count);
 
-            selectedStages.Add(selectableStages[stageNum]);
+            chosenStages[i] = stageNum;
         }
+
+        RPC_BroadcastSelectedStages(chosenStages);
+    }
+
+    [Rpc(RpcSources.StateAuthority, RpcTargets.All, HostMode = RpcHostMode.SourceIsServer)]
+    public void RPC_BroadcastSelectedStages(int [] chosenStages)
+    {
+        selectedStages.Clear();
+        foreach (int idx in chosenStages)
+            selectedStages.Add(selectableStages[idx]);
     }
 
     #region Stage Management

--- a/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
@@ -27,17 +27,16 @@ public class GameManager : NetworkBehaviour
     /// <summary>
     /// 게임을 초기화하고 첫 번째 스테이지를 시작하는 메서드
     /// </summary>
-    [ContextMenu("InitializeStagesAndStart")]
     public void InitializeStagesAndStart()
     {
+        // 서버이자 해당 NetworkObject의 StateAuthority를 가진 경우에만 실행
+        if (!(Runner.IsServer && HasStateAuthority))
+            return;
+
         Debug.Log("InitializeStagesAndStart");
 
-        if (Runner.IsServer && HasStateAuthority)
-        {
-            Debug.Log("HasStateAuthority");
-            SelectRandomUniqueStage();  // 랜덤으로 스테이지 선택
-        }
-        //MoveNextStage();            // 첫 번째 스테이지로 이동
+        SelectRandomUniqueStage();  // 랜덤으로 스테이지 선택
+        RpcMoveNextStage(); // 첫 번째 스테이지로 이동
     }
 
     /// <summary>
@@ -78,7 +77,7 @@ public class GameManager : NetworkBehaviour
     /// </summary>
     /// <param name="chosenStages">서버가 선정한 인덱스 배열</param>
     [Rpc(RpcSources.StateAuthority, RpcTargets.All, HostMode = RpcHostMode.SourceIsServer)]
-    public void RPC_BroadcastSelectedStages(int [] chosenStages)
+    private void RPC_BroadcastSelectedStages(int [] chosenStages)
     {
         selectedStages.Clear();
         foreach (int idx in chosenStages)
@@ -87,34 +86,31 @@ public class GameManager : NetworkBehaviour
 
     #region Stage Management
     /// <summary>
-    /// 선택된 스테이지 목록에서 다음 스테이지로 이동하는 메서드
+    /// 선택된 스테이지 목록에서 다음 스테이지로 이동하는 RPC 메서드
+    /// 서버(StateAuthority)에서 호출되며, 모든 클라이언트에게 스테이지 전환을 동기화함.
+    /// isExtraStage가 true일 경우, 추가 스테이지를 동적으로 선택하여 목록에 포함시킴.
     /// </summary>
-    private void MoveNextStage()
+    /// <param name="isExtraStage">true이면 선택 가능한 스테이지 중 하나를 추가로 선택함</param>
+    [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
+    private void RpcMoveNextStage(bool isExtraStage = false)
     {
-        Debug.Log("스테이지를 이동합니다.");
+        // 추가 스테이지가 필요한 경우, 랜덤으로 하나를 선택해 selectedStages에 추가
+        if (isExtraStage)
+        {
+            int extraStageNum = Random.Range(0, selectableStages.Count);
+            selectedStages.Add(selectableStages[extraStageNum]); // 추가로 선택된 스테이지를 selectedStages 리스트에 추가
+        }
 
-        //TODO... 다음 스테이지 로딩 UI 활성화
-        if (ongoingStage >= 0)
-            selectedStages[ongoingStage].gameObject.SetActive(false);   // 현재 스테이지 비활성화
-
-        selectedStages[++ongoingStage].gameObject.SetActive(true);   // 다음 스테이지 활성화
-        //TODO... 다음 스테이지 로딩 UI 비활성화
-    }
-
-    /// <summary>
-    /// 특정 추가 스테이지로 이동하는 메서드
-    /// </summary>
-    /// <param name="stageNum">이동할 추가 스테이지의 인덱스</param>
-    private void MoveNextStage(int stageNum)
-    {
-        Debug.Log("추가 스테이지로 이동합니다.");
+        // 이전 스테이지가 존재하면 비활성화
+        if (ongoingStage >= 0 && ongoingStage < selectedStages.Count)
+            selectedStages[ongoingStage].gameObject.SetActive(false);
         
-        //TODO... 다음 스테이지 로딩 UI 활성화
-        selectedStages.Add(selectableStages[stageNum]); // 추가로 선택된 스테이지를 selectedStages 리스트에 추가
-        selectedStages[ongoingStage].gameObject.SetActive(false);   // 현재 스테이지 비활성화
-        selectedStages[++ongoingStage].gameObject.SetActive(true);   // 다음 스테이지 활성화
-        //TODO... 다음 스테이지 로딩 UI 활성화
+        // 다음 스테이지로 진행
+        ongoingStage++;
 
+        // 다음 스테이지가 존재하면 활성화
+        if (ongoingStage < selectedStages.Count)
+            selectedStages[ongoingStage].gameObject.SetActive(true);
     }
     #endregion
 
@@ -124,8 +120,8 @@ public class GameManager : NetworkBehaviour
     /// </summary>
     public void ProcessStageCompletion()
     {
-        if (ongoingStage + 1 < MIN_STAGE_COUNT)
-            MoveNextStage();    // 다음 스테이지 이동
+        if (Runner.IsServer && HasStateAuthority && ongoingStage + 1 < MIN_STAGE_COUNT)
+            RpcMoveNextStage();    // 다음 스테이지 이동
         else
         {
             // TODO... 추가 스테이지를 진행해야 하는지 여부 결정하는 로직 구현

--- a/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
@@ -77,6 +77,11 @@ public class GameManager : NetworkBehaviour
         RPC_BroadcastSelectedStages(chosenStages);
     }
 
+    /// <summary>
+    /// 서버에서 선택한 스테이지 인덱스 배열을 모든 클라이언트에 동기화하는 RPC 메서드
+    /// 선택된 인덱스를 기반으로 selectedStages 리스트를 클라이언트마다 동일하게 구성
+    /// </summary>
+    /// <param name="chosenStages">서버가 선정한 인덱스 배열</param>
     [Rpc(RpcSources.StateAuthority, RpcTargets.All, HostMode = RpcHostMode.SourceIsServer)]
     public void RPC_BroadcastSelectedStages(int [] chosenStages)
     {

--- a/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
@@ -32,11 +32,6 @@ public class GameManager : NetworkBehaviour
     {
         Debug.Log("InitializeStagesAndStart");
 
-        if (Runner == null)
-            Debug.Log("Runner is Null");
-        else
-            Debug.Log(Runner.gameObject.name);
-
         if (Runner.IsServer && HasStateAuthority)
         {
             Debug.Log("HasStateAuthority");

--- a/Assets/Workspace/Lee_yerin/Scripts/SessionManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/SessionManager.cs
@@ -72,6 +72,8 @@ public class SessionManager : MonoBehaviour
         // 세션 연결 시작
         if (_isHost)
         {
+            // 현재 활성화된 씬의 build index를 SceneRef로 변환하여 지정 (Fusion이 씬을 재로드하도록 유도)
+            var sceneRef = SceneRef.FromIndex(SceneManager.GetActiveScene().buildIndex);
             // Host인 경우 방 생성
             await _runner.StartGame(new StartGameArgs()
             {
@@ -82,7 +84,8 @@ public class SessionManager : MonoBehaviour
                 // 기본 씬 매니저 추가
                 // 씬 로딩 및 동기화를 자동으로 지원해줌
                 SceneManager = gameObject.AddComponent<NetworkSceneManagerDefault>(),
-                Scene = null,
+                // Scene을 null이 아닌 실제 현재 씬으로 명시 (씬 내 NetworkObject 자동 등록 유도)
+                Scene = sceneRef,
                 PlayerCount = 4
             });
         }

--- a/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
@@ -1,3 +1,4 @@
+using Fusion;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
@@ -8,7 +9,7 @@ using UnityEngine;
 /// 
 /// 스테이지의 기본 동작을 관리하는 클래스
 /// </summary>
-public class StageManager : MonoBehaviour
+public class StageManager : NetworkBehaviour
 {
     [Header("Time")]
     [Tooltip("스테이지의 전체 타이머 (초 단위로 설정)")]
@@ -22,7 +23,7 @@ public class StageManager : MonoBehaviour
     /// <summary>
     /// 스테이지의 종료 여부를 반환하는 프로퍼티
     /// </summary>
-    public bool IsFinished { get; private set; }
+    public NetworkBool IsFinished { get; private set; }
 
     #region Unitye Event
     private void OnEnable()
@@ -95,7 +96,7 @@ public class StageManager : MonoBehaviour
         IsFinished = true;
         stageLogic = null;
 
-        GameManager.Instance.ProcessStageCompletion();
+        // GameManager.Instance.ProcessStageCompletion();
     }
     #endregion
 }

--- a/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
@@ -31,7 +31,7 @@ public class StageManager : NetworkBehaviour
     #region Unitye Event
     private void OnEnable()
     {
-        if (gameManager != null)
+        if (gameManager == null)
         {
             Debug.LogError("해당 스테이지에 GameManager가 할당되지 않아 정상적인 게임 로직 실행 불가능");
             return;

--- a/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
@@ -11,6 +11,9 @@ using UnityEngine;
 /// </summary>
 public class StageManager : NetworkBehaviour
 {
+    [Header("GameManager")]
+    [SerializeField] GameManager gameManager;
+
     [Header("Time")]
     [Tooltip("스테이지의 전체 타이머 (초 단위로 설정)")]
     [SerializeField] float stageTime;
@@ -28,6 +31,12 @@ public class StageManager : NetworkBehaviour
     #region Unitye Event
     private void OnEnable()
     {
+        if (gameManager != null)
+        {
+            Debug.LogError("해당 스테이지에 GameManager가 할당되지 않아 정상적인 게임 로직 실행 불가능");
+            return;
+        }
+
         // 생존 중인 플레이어가 없거나 리스트가 비어 있으면, 스테이지 실행을 중지하고 메시지 출력
         /*if (alivePlayers == null || alivePlayers.Count == 0)
         {
@@ -96,7 +105,7 @@ public class StageManager : NetworkBehaviour
         IsFinished = true;
         stageLogic = null;
 
-        // GameManager.Instance.ProcessStageCompletion();
+        gameManager.ProcessStageCompletion();
     }
     #endregion
 }

--- a/Assets/Workspace/Lee_yerin/Scripts/Test_Start.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/Test_Start.cs
@@ -7,6 +7,6 @@ public class Test_Start : MonoBehaviour
 {
     public void GoToGameScene()
     {
-        SceneManager.LoadScene("Room_Test");
+        SceneManager.LoadScene("Room_Test_Scene");
     }
 }


### PR DESCRIPTION
- GameManager를 싱글톤에서 비싱글톤(인스펙터 할당 방식)으로 전환
- SelectRandomUniqueStage 결과를 클라이언트와 공유하도록 RPC 적용
- MoveNextStage를 RpcMoveNextStage로 대체하여 스테이지 전환을 동기화
- 기존 오버로딩된 MoveNextStage(int) 제거 → bool 매개변수로 통합
- StateAuthority 체크 및 Runner null 문제 대응
- SceneRef 명시로 씬 내 NetworkObject 자동 등록 문제 해결

기능상 변화 외에도 구조적으로 게임 상태 흐름의 명확성과 확장성을 확보했습니다.