### PR TITLE
스테이지별 지정 위치에 캐릭터 스폰 및 캐릭터 사망과 스테이지 로직 연결

### DIFF
--- a/Assets/Resources/Character/Player 1.prefab
+++ b/Assets/Resources/Character/Player 1.prefab
@@ -128,6 +128,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 3317617978666817901}
   - {fileID: 952355318055887179}
   - {fileID: 8041304104161485888}
   - {fileID: -4294851122239989272}
@@ -224,11 +225,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 98f2ef66dee584f45877186636b9df8d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _stateAuthorityChangeErrorCorrectionDelta: 1
-  SyncScale: 0
-  SyncParent: 0
-  _autoAOIOverride: 1
-  DisableSharedModeInterpolation: 0
 --- !u!114 &-4294851122239989272
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Character/Player 1_1.prefab
+++ b/Assets/Resources/Character/Player 1_1.prefab
@@ -92,6 +92,7 @@ MonoBehaviour:
   AttackDamage: 30
   skill: {fileID: 11400000, guid: 6de4f0bd562dab5428573255c0406f05, type: 2}
   firePoint: {fileID: 2121775484220535461}
+  networkObject: {fileID: 5622140301583662809}
 --- !u!114 &5622140301583662809
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -109,6 +110,7 @@ MonoBehaviour:
   Flags: 262145
   NestedObjects: []
   NetworkedBehaviours:
+  - {fileID: 3317617978666817901}
   - {fileID: 952355318055887179}
   - {fileID: 2631188256620354680}
   - {fileID: 4939370475143424285}

--- a/Assets/Resources/Character/Player.prefab
+++ b/Assets/Resources/Character/Player.prefab
@@ -125,7 +125,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 634cf6cf338f47748ba101cf0df114de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  kcc: {fileID: 0}
+  character: {fileID: 0}
   moveSpeed: 5
+  jumpImpulse: 10
+  upGravity: -25
+  downGravity: -40
+  groundAcceleration: 50
+  groundDeceleration: 25
+  airAcceleration: 20
+  airDeceleration: 2
 --- !u!114 &3317617978666817901
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -139,8 +148,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterName: Player1
+  animator: {fileID: 0}
   maxHp: 1000
   currentHp: 1000
+  AttackCooltime: 1
+  AttackRange: 2
+  AttackDamage: 20
+  skill: {fileID: 0}
   firePoint: {fileID: 0}
 --- !u!114 &5622140301583662809
 MonoBehaviour:
@@ -160,6 +174,7 @@ MonoBehaviour:
   NestedObjects: []
   NetworkedBehaviours:
   - {fileID: 9101149634733263506}
+  - {fileID: 3317617978666817901}
   - {fileID: 6584874301793632186}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &6584874301793632186

--- a/Assets/Workspace/Lee_yerin/Prefabs/NetworkRunnerPrefab.prefab
+++ b/Assets/Workspace/Lee_yerin/Prefabs/NetworkRunnerPrefab.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 209570764108773333}
   - component: {fileID: 3515418673216946386}
   - component: {fileID: 5886083178202401678}
-  - component: {fileID: 6786508028328907048}
   m_Layer: 0
   m_Name: NetworkRunnerPrefab
   m_TagString: Untagged
@@ -131,6 +130,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   PlayerPrefab: {fileID: 4018240343111223314, guid: d0b64caa744770241904160b838db386,
     type: 3}
+  pendingPlayers: []
 --- !u!114 &5886083178202401678
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -143,21 +143,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8edbe7108d8a43ab838cf8b8d9453df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &6786508028328907048
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2066214651548133740}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SortKey: 2300249409
-  ObjectInterest: 1
-  Flags: 262145
-  NestedObjects: []
-  NetworkedBehaviours: []
-  ForceRemoteRenderTimeframe: 0

--- a/Assets/Workspace/Lee_yerin/Prefabs/NetworkRunnerPrefab.prefab.meta
+++ b/Assets/Workspace/Lee_yerin/Prefabs/NetworkRunnerPrefab.prefab.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 8a002b6ab81544a49b6616935a088c96
-labels:
-- FusionPrefab
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Workspace/Lee_yerin/Scenes/Room_Test_Scene.unity
+++ b/Assets/Workspace/Lee_yerin/Scenes/Room_Test_Scene.unity
@@ -123,7 +123,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &48506808
+--- !u!1 &19038009
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -131,25 +131,199 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 48506812}
-  - component: {fileID: 48506811}
-  - component: {fileID: 48506810}
-  - component: {fileID: 48506809}
-  - component: {fileID: 48506813}
+  - component: {fileID: 19038010}
   m_Layer: 0
-  m_Name: Stage 2
+  m_Name: Point1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &19038010
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 19038009}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 769041432}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &22336705
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22336706}
+  m_Layer: 0
+  m_Name: SpwanPoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &22336706
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 22336705}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 628188160}
+  - {fileID: 44326327}
+  - {fileID: 402396300}
+  - {fileID: 680174600}
+  m_Father: {fileID: 1761584709}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &29203590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 29203591}
+  m_Layer: 0
+  m_Name: Point4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &29203591
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 29203590}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 769041432}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &44326326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 44326327}
+  m_Layer: 0
+  m_Name: Point2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &44326327
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 44326326}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 22336706}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &89378649
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 89378650}
+  m_Layer: 0
+  m_Name: Point3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &89378650
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89378649}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1340567498}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &146068163
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 146068164}
+  - component: {fileID: 146068167}
+  - component: {fileID: 146068166}
+  - component: {fileID: 146068165}
+  m_Layer: 0
+  m_Name: StageObj
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!65 &48506809
+--- !u!4 &146068164
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146068163}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 2, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1966465425}
+  m_Father: {fileID: 1813416506}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &146068165
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48506808}
+  m_GameObject: {fileID: 146068163}
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -164,13 +338,13 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &48506810
+--- !u!23 &146068166
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48506808}
+  m_GameObject: {fileID: 146068163}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -206,49 +380,15 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &48506811
+--- !u!33 &146068167
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48506808}
+  m_GameObject: {fileID: 146068163}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &48506812
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48506808}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 2, z: 10}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &48506813
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48506808}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  gameManager: {fileID: 759923966}
-  stageTime: 10
-  alivePlayers:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
---- !u!1 &71144323
+--- !u!1 &228408165
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -256,123 +396,60 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 71144327}
-  - component: {fileID: 71144326}
-  - component: {fileID: 71144325}
-  - component: {fileID: 71144324}
-  - component: {fileID: 71144328}
+  - component: {fileID: 228408166}
   m_Layer: 0
-  m_Name: Stage 3
+  m_Name: Point3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!65 &71144324
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71144323}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &71144325
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71144323}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &71144326
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71144323}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &71144327
+  m_IsActive: 1
+--- !u!4 &228408166
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71144323}
+  m_GameObject: {fileID: 228408165}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 2, z: 10}
+  m_LocalPosition: {x: -0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 769041432}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &71144328
-MonoBehaviour:
+--- !u!1 &292488615
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 71144323}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  gameManager: {fileID: 759923966}
-  stageTime: 10
-  alivePlayers:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 292488616}
+  m_Layer: 0
+  m_Name: Point2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &292488616
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292488615}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1966465425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &303599970
 GameObject:
   m_ObjectHideFlags: 0
@@ -441,6 +518,309 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &402396299
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 402396300}
+  m_Layer: 0
+  m_Name: Point3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &402396300
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 402396299}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 22336706}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &424445467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 424445468}
+  m_Layer: 0
+  m_Name: Point2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &424445468
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 424445467}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 769041432}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &470272712
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 470272713}
+  m_Layer: 0
+  m_Name: Point1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &470272713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 470272712}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1340567498}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &531784655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 531784658}
+  - component: {fileID: 531784657}
+  - component: {fileID: 531784656}
+  m_Layer: 0
+  m_Name: Stage4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &531784656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531784655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SortKey: 2455821142
+  ObjectInterest: 1
+  Flags: 262145
+  NestedObjects: []
+  NetworkedBehaviours:
+  - {fileID: 531784657}
+  ForceRemoteRenderTimeframe: 0
+--- !u!114 &531784657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531784655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stageVisualRoot: {fileID: 1988909364}
+  gameManager: {fileID: 759923966}
+  stageTime: 10
+  alivePlayers: []
+  playersSpawnPoints:
+  - {fileID: 19038010}
+  - {fileID: 424445468}
+  - {fileID: 228408166}
+  - {fileID: 29203591}
+--- !u!4 &531784658
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 531784655}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1988909365}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &628188159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 628188160}
+  m_Layer: 0
+  m_Name: Point1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &628188160
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 628188159}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 22336706}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &680174599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 680174600}
+  m_Layer: 0
+  m_Name: Point4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &680174600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 680174599}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 22336706}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &682772513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 682772516}
+  - component: {fileID: 682772515}
+  - component: {fileID: 682772514}
+  m_Layer: 0
+  m_Name: Stage1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &682772514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682772513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SortKey: 699601778
+  ObjectInterest: 1
+  Flags: 262145
+  NestedObjects: []
+  NetworkedBehaviours:
+  - {fileID: 682772515}
+  ForceRemoteRenderTimeframe: 0
+--- !u!114 &682772515
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682772513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stageVisualRoot: {fileID: 1169630482}
+  gameManager: {fileID: 759923966}
+  stageTime: 10
+  alivePlayers: []
+  playersSpawnPoints:
+  - {fileID: 470272713}
+  - {fileID: 1751804204}
+  - {fileID: 89378650}
+  - {fileID: 1426373606}
+--- !u!4 &682772516
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682772513}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1169630486}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &759923963
 GameObject:
   m_ObjectHideFlags: 0
@@ -487,12 +867,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   selectableStages:
-  - {fileID: 1169630487}
-  - {fileID: 48506813}
-  - {fileID: 71144328}
-  - {fileID: 1029047546}
+  - {fileID: 682772515}
+  - {fileID: 1223615731}
+  - {fileID: 1813416505}
+  - {fileID: 531784657}
   selectedStages: []
   ongoingStage: -1
+  playerCharacters: []
+  playerSpawner: {fileID: 0}
 --- !u!114 &759923967
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -512,6 +894,41 @@ MonoBehaviour:
   NetworkedBehaviours:
   - {fileID: 759923966}
   ForceRemoteRenderTimeframe: 0
+--- !u!1 &769041431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 769041432}
+  m_Layer: 0
+  m_Name: SpwanPoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &769041432
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769041431}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 19038010}
+  - {fileID: 424445468}
+  - {fileID: 228408166}
+  - {fileID: 29203591}
+  m_Father: {fileID: 1988909365}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &844762418
 GameObject:
   m_ObjectHideFlags: 0
@@ -726,7 +1143,7 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &1029047541
+--- !u!1 &1063516738
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -734,123 +1151,29 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1029047545}
-  - component: {fileID: 1029047544}
-  - component: {fileID: 1029047543}
-  - component: {fileID: 1029047542}
-  - component: {fileID: 1029047546}
+  - component: {fileID: 1063516739}
   m_Layer: 0
-  m_Name: Stage 4
+  m_Name: Point3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!65 &1029047542
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1029047541}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1029047543
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1029047541}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1029047544
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1029047541}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1029047545
+  m_IsActive: 1
+--- !u!4 &1063516739
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1029047541}
+  m_GameObject: {fileID: 1063516738}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 2, z: 10}
+  m_LocalPosition: {x: -0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1966465425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1029047546
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1029047541}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  gameManager: {fileID: 759923966}
-  stageTime: 10
-  alivePlayers:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
 --- !u!1 &1169630482
 GameObject:
   m_ObjectHideFlags: 0
@@ -863,9 +1186,8 @@ GameObject:
   - component: {fileID: 1169630485}
   - component: {fileID: 1169630484}
   - component: {fileID: 1169630483}
-  - component: {fileID: 1169630487}
   m_Layer: 0
-  m_Name: Stage 1
+  m_Name: StageObj
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -950,32 +1272,185 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1169630482}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 10, y: 2, z: 10}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
+  m_Children:
+  - {fileID: 1340567498}
+  m_Father: {fileID: 682772516}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1169630487
+--- !u!1 &1223615729
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1223615732}
+  - component: {fileID: 1223615731}
+  - component: {fileID: 1223615730}
+  m_Layer: 0
+  m_Name: Stage2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1223615730
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1169630482}
+  m_GameObject: {fileID: 1223615729}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SortKey: 4064815522
+  ObjectInterest: 1
+  Flags: 262145
+  NestedObjects: []
+  NetworkedBehaviours:
+  - {fileID: 1223615731}
+  ForceRemoteRenderTimeframe: 0
+--- !u!114 &1223615731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1223615729}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  stageVisualRoot: {fileID: 1761584708}
   gameManager: {fileID: 759923966}
   stageTime: 10
-  alivePlayers:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
+  alivePlayers: []
+  playersSpawnPoints:
+  - {fileID: 628188160}
+  - {fileID: 44326327}
+  - {fileID: 402396300}
+  - {fileID: 680174600}
+--- !u!4 &1223615732
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1223615729}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1761584709}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1267486587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1267486588}
+  m_Layer: 0
+  m_Name: Point1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1267486588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267486587}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1966465425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1340567497
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1340567498}
+  m_Layer: 0
+  m_Name: SpwanPoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1340567498
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340567497}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 470272713}
+  - {fileID: 1751804204}
+  - {fileID: 89378650}
+  - {fileID: 1426373606}
+  m_Father: {fileID: 1169630486}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1426373605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1426373606}
+  m_Layer: 0
+  m_Name: Point4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1426373606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1426373605}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1340567498}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1563928843
 GameObject:
   m_ObjectHideFlags: 0
@@ -1268,6 +1743,248 @@ MonoBehaviour:
   Components:
   - {fileID: 1719807576}
   _guid: ab67c6c2-fe8e-4e64-
+--- !u!1 &1744602040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1744602041}
+  m_Layer: 0
+  m_Name: Point4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1744602041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744602040}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1966465425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1751804203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1751804204}
+  m_Layer: 0
+  m_Name: Point2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1751804204
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751804203}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 4, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1340567498}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1761584708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1761584709}
+  - component: {fileID: 1761584712}
+  - component: {fileID: 1761584711}
+  - component: {fileID: 1761584710}
+  m_Layer: 0
+  m_Name: StageObj
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1761584709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761584708}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 2, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 22336706}
+  m_Father: {fileID: 1223615732}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1761584710
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761584708}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1761584711
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761584708}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1761584712
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761584708}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1813416503
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1813416506}
+  - component: {fileID: 1813416505}
+  - component: {fileID: 1813416504}
+  m_Layer: 0
+  m_Name: Stage3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1813416504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1813416503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SortKey: 1853122238
+  ObjectInterest: 1
+  Flags: 262145
+  NestedObjects: []
+  NetworkedBehaviours:
+  - {fileID: 1813416505}
+  ForceRemoteRenderTimeframe: 0
+--- !u!114 &1813416505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1813416503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1f31781798ace5438df2ecea24d6685, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stageVisualRoot: {fileID: 146068163}
+  gameManager: {fileID: 759923966}
+  stageTime: 10
+  alivePlayers: []
+  playersSpawnPoints:
+  - {fileID: 1267486588}
+  - {fileID: 292488616}
+  - {fileID: 1063516739}
+  - {fileID: 1744602041}
+--- !u!4 &1813416506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1813416503}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 146068164}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1870849580
 GameObject:
   m_ObjectHideFlags: 0
@@ -1512,6 +2229,147 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1890121831}
   m_CullTransparentMesh: 1
+--- !u!1 &1966465424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1966465425}
+  m_Layer: 0
+  m_Name: SpwanPoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1966465425
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966465424}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1267486588}
+  - {fileID: 292488616}
+  - {fileID: 1063516739}
+  - {fileID: 1744602041}
+  m_Father: {fileID: 146068164}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1988909364
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1988909365}
+  - component: {fileID: 1988909368}
+  - component: {fileID: 1988909367}
+  - component: {fileID: 1988909366}
+  m_Layer: 0
+  m_Name: StageObj
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1988909365
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1988909364}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 2, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 769041432}
+  m_Father: {fileID: 531784658}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1988909366
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1988909364}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1988909367
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1988909364}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1988909368
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1988909364}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1520,9 +2378,9 @@ SceneRoots:
   - {fileID: 1870849582}
   - {fileID: 759923964}
   - {fileID: 1563928845}
-  - {fileID: 1169630486}
-  - {fileID: 48506812}
-  - {fileID: 71144327}
-  - {fileID: 1029047545}
+  - {fileID: 682772516}
+  - {fileID: 1223615732}
+  - {fileID: 1813416506}
+  - {fileID: 531784658}
   - {fileID: 878013269}
   - {fileID: 303599973}

--- a/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
@@ -1,4 +1,5 @@
 using Fusion;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -135,11 +136,45 @@ public class GameManager : NetworkBehaviour
 
         if (Runner.IsServer)
         {
-            foreach (NetworkObject character in playerSpawner?.SpawnAllPendingPlayers(selectedStages[ongoingStage].PlayersSpawnPoints)) // 플레이어 캐릭터 스폰 시작
+            foreach (NetworkObject character in playerSpawner?.SpawnAllPendingPlayers(selectedStages[ongoingStage].PlayersSpawnPoints))
+            {
                 playerCharacters.Add(character);
+            }
+        }
+        else
+        {
+            // 클라이언트 playerCharacters 동기화 작업 실행
+            StartCoroutine(RebuildPlayerCharactersNextFrame());
         }
 
-        selectedStages[ongoingStage].StartLogic();  // 스테이지 로직 실행
+            selectedStages[ongoingStage].StartLogic();  // 스테이지 로직 실행
+    }
+
+    /// <summary>
+    /// 클라이언트에서 Fusion 동기화가 완료된 이후,
+    /// 각 플레이어에 대응하는 NetworkObject를 수집하여 playerCharacters 리스트를 재구성하는 코루틴입니다.
+    /// Fusion의 SetPlayerObject 등록 이후 동기화 지연을 고려하여 한 프레임 뒤에 실행됩니다.
+    /// </summary>
+    /// <returns>코루틴 대기를 위한 IEnumerator</returns>
+    private IEnumerator RebuildPlayerCharactersNextFrame()
+    {
+        yield return null;
+
+        playerCharacters.Clear();
+
+        foreach (var player in Runner.ActivePlayers)
+        {
+            if (Runner.TryGetPlayerObject(player, out var obj))
+            {
+                playerCharacters.Add(obj);
+            }
+            else
+            {
+                Debug.LogWarning($"[Client] Player {player.PlayerId}의 오브젝트를 찾을 수 없습니다.");
+            }
+        }
+
+        Debug.Log($"[Client] playerCharacters 복구 완료: {playerCharacters.Count}개");
     }
     #endregion
 

--- a/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/GameManager.cs
@@ -1,8 +1,6 @@
 using Fusion;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 /// <summary>
 /// 개발자: 이예린
@@ -12,23 +10,35 @@ using UnityEngine.SceneManagement;
 public class GameManager : NetworkBehaviour
 {
     #region Variables
+    [Header("Game Logic")]
     //TODO... Fusion 연결 후 룸 안에 있는 플레이어 받아와 저장
     [SerializeField] List<StageManager> selectableStages; // 선택 가능한 스테이지 목록
     [SerializeField] List<StageManager> selectedStages;   // 선택된 스테이지 목록
 
     const int MIN_STAGE_COUNT = 3;  // 최소 스테이지 개수
-    [SerializeField] int ongoingStage = -1;   // 현재 진행 중인 스테이지 인덱스
+    [SerializeField] public int ongoingStage = -1;   // 현재 진행 중인 스테이지 인덱스
+
+    [SerializeField] public List<NetworkObject> playerCharacters;
+    [SerializeField] PlayerSpawner playerSpawner;
     #endregion
 
     #region Unity Event
     #endregion
 
     #region Game Logic
+    public void InitializeStagesAndStart()
+    {
+        RPC_InitializeStagesAndStart();
+    }
+
     /// <summary>
     /// 게임을 초기화하고 첫 번째 스테이지를 시작하는 메서드
     /// </summary>
-    public void InitializeStagesAndStart()
+    [Rpc(RpcSources.StateAuthority, RpcTargets.All, HostMode = RpcHostMode.SourceIsServer)]
+    public void RPC_InitializeStagesAndStart()
     {
+        playerSpawner = Runner.gameObject.GetComponent<PlayerSpawner>();
+
         // 서버이자 해당 NetworkObject의 StateAuthority를 가진 경우에만 실행
         if (!(Runner.IsServer && HasStateAuthority))
             return;
@@ -36,7 +46,9 @@ public class GameManager : NetworkBehaviour
         Debug.Log("InitializeStagesAndStart");
 
         SelectRandomUniqueStage();  // 랜덤으로 스테이지 선택
+
         RpcMoveNextStage(); // 첫 번째 스테이지로 이동
+        Debug.Log(playerCharacters.Count);
     }
 
     /// <summary>
@@ -103,14 +115,31 @@ public class GameManager : NetworkBehaviour
 
         // 이전 스테이지가 존재하면 비활성화
         if (ongoingStage >= 0 && ongoingStage < selectedStages.Count)
-            selectedStages[ongoingStage].gameObject.SetActive(false);
-        
+        {
+            selectedStages[ongoingStage].ActivateStage(false);
+
+            foreach (NetworkObject player in playerCharacters)
+            {
+                Runner.Despawn(player);
+            }
+        }
+
         // 다음 스테이지로 진행
         ongoingStage++;
 
         // 다음 스테이지가 존재하면 활성화
         if (ongoingStage < selectedStages.Count)
-            selectedStages[ongoingStage].gameObject.SetActive(true);
+            selectedStages[ongoingStage].ActivateStage(true);
+
+        playerCharacters.Clear();
+
+        if (Runner.IsServer)
+        {
+            foreach (NetworkObject character in playerSpawner?.SpawnAllPendingPlayers(selectedStages[ongoingStage].PlayersSpawnPoints)) // 플레이어 캐릭터 스폰 시작
+                playerCharacters.Add(character);
+        }
+
+        selectedStages[ongoingStage].StartLogic();  // 스테이지 로직 실행
     }
     #endregion
 

--- a/Assets/Workspace/Lee_yerin/Scripts/PlayerSpawner.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/PlayerSpawner.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.XR;
 
 /// <summary>
 /// 개발자: 이예린
@@ -40,6 +41,9 @@ public class PlayerSpawner : SimulationBehaviour, IPlayerJoined, IPlayerLeft
             if (playerObj == null)
                 Debug.Log("플레이어 생성 안 됨");
 
+            // Fusion 내부에 등록 (클라이언트에서도 이 오브젝트 찾을 수 있도록)
+            Runner.SetPlayerObject(player, playerObj);
+
             // 플레이어 오브젝트 HasInputAuthority 확인용 
             if (playerObj.HasInputAuthority)
             {
@@ -73,10 +77,12 @@ public class PlayerSpawner : SimulationBehaviour, IPlayerJoined, IPlayerLeft
         }
 
         // Host만 Spawn 책임을 진다 권한 부여는 InputHandler에.
-        if (Runner.IsServer)
+        /*if (Runner.IsServer)
         {
             pendingPlayers.Add(player); // 대기 등록
-        }
+        }*/
+
+        pendingPlayers.Add(player); // 대기 등록
     }
 
     /// <summary>

--- a/Assets/Workspace/Lee_yerin/Scripts/PlayerSpawner.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/PlayerSpawner.cs
@@ -9,31 +9,32 @@ using UnityEngine.InputSystem;
 /// 개발자: 이예린
 /// 플레이어를 스폰하는 클래스
 /// </summary>
-public class PlayerSpawner : SimulationBehaviour, IPlayerJoined
+public class PlayerSpawner : SimulationBehaviour, IPlayerJoined, IPlayerLeft
 {
     public GameObject PlayerPrefab;
+
+    [SerializeField] public List<PlayerRef> pendingPlayers = new List<PlayerRef>();
+
     [ContextMenu("Spawn")]
     #region Spawn
     [ContextMenu("Spawn")]
-    private void SpawnPlayer(PlayerRef player)
+    private NetworkObject SpawnPlayer(PlayerRef player, Transform spawnPoint)
     {
         try
         {
-
-
             if (Runner == null)
             {
                 Debug.LogError("Runner가 설정되어 있지 않습니다.");
-                return;
+                return null;
             }
 
             if (PlayerPrefab == null)
             {
                 Debug.LogError("Player Prefab이 설정되어 있지 않습니다.");
-                return;
+                return null;
             }
 
-            NetworkObject playerObj = Runner.Spawn(PlayerPrefab, new Vector3(0, 1, 0), Quaternion.identity, player);
+            NetworkObject playerObj = Runner.Spawn(PlayerPrefab, spawnPoint.position, Quaternion.identity, player);
 
 
             if (playerObj == null)
@@ -48,13 +49,20 @@ public class PlayerSpawner : SimulationBehaviour, IPlayerJoined
             {
                 Debug.Log("이건 내가 조작할 수 있는 플레이어가 아닙니다.");
             }
+
+            return playerObj;
         }
         catch (Exception e)
         {
             Debug.LogError("Runner.Spawn 중 예외 발생: " + e.Message);
+            return null;
         }
     }
 
+    /// <summary>
+    /// 게임 안에 플레이어 들어올 때 호출되는 메서드
+    /// </summary>
+    /// <param name="player"></param>
     public void PlayerJoined(PlayerRef player)
     {
         Debug.Log(player);
@@ -67,14 +75,42 @@ public class PlayerSpawner : SimulationBehaviour, IPlayerJoined
         // Host만 Spawn 책임을 진다 권한 부여는 InputHandler에.
         if (Runner.IsServer)
         {
-            SpawnPlayer(player);
+            pendingPlayers.Add(player); // 대기 등록
         }
-        /*
-        if (Runner.IsClient)
+    }
+
+    /// <summary>
+    /// 게임에서 플레이어 떠날 시 호출되는 메서드
+    /// pendingPlayers 리스트에서 떠난 플레이어 삭제
+    /// </summary>
+    /// <param name="player">PlayerRef</param>
+    public void PlayerLeft(PlayerRef player)
+    {
+        /*if (!Runner.IsServer)
+            return;*/
+
+        Debug.Log($"[Spawner] {player}가 떠났습니다. 리스트에서 제거합니다.");
+        pendingPlayers.Remove(player);
+    }
+
+    /// <summary>
+    /// 게임 안 모든 플레이어의 캐릭터 스폰하는 메서드
+    /// </summary>
+    /// <param name="spawnPoints">캐릭터 스폰할 위치 리스트</param>
+    /// <returns></returns>
+    public List<NetworkObject> SpawnAllPendingPlayers(List<Transform> spawnPoints)
+    {
+        if (!Runner.IsServer)
+            return null;
+
+        List<NetworkObject> playerCharacters = new();
+
+        for (int i = 0; i < pendingPlayers.Count; i++)
         {
-            Runner.ProvideInput = true;
+            playerCharacters.Add(SpawnPlayer(pendingPlayers[i], spawnPoints[i]));
         }
-        */
+
+        return playerCharacters;
     }
     #endregion
 }

--- a/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
+using System.Linq;
+using Fusion.Addons.SimpleKCC;
 
 /// <summary>
 /// 개발자: 이예린
@@ -11,6 +13,10 @@ using UnityEngine;
 /// </summary>
 public class StageManager : NetworkBehaviour
 {
+    [Header("StageObju")]
+    [SerializeField] private GameObject stageVisualRoot; // 내부 오브젝트 묶음
+    public GameObject StageVisualRoot => stageVisualRoot;
+
     [Header("GameManager")]
     [SerializeField] GameManager gameManager;
 
@@ -18,9 +24,13 @@ public class StageManager : NetworkBehaviour
     [Tooltip("스테이지의 전체 타이머 (초 단위로 설정)")]
     [SerializeField] float stageTime;
 
-    [Header("Current players in stage ")]
+    [Header("Players")]
     [Tooltip("현재 스테이지에서 생존 중인 플레이어들 보관하는 List")]
-    [SerializeField] List<Object> alivePlayers = new();
+    [SerializeField] List<NetworkObject> alivePlayers;
+
+    [Tooltip("플레이어들 스폰 위치 List")]
+    [SerializeField] List<Transform> playersSpawnPoints;
+    public List<Transform> PlayersSpawnPoints => playersSpawnPoints;
 
     Coroutine stageLogic = null;    // 스테이지 로직을 실행하는 코루틴 참조
     /// <summary>
@@ -28,21 +38,17 @@ public class StageManager : NetworkBehaviour
     /// </summary>
     public NetworkBool IsFinished { get; private set; }
 
-    #region Unitye Event
-    private void OnEnable()
+    #region Stage Logic
+    /// <summary>
+    /// 스테이지 로직 실행하는 메서드
+    /// </summary>
+    public void StartLogic()
     {
         if (gameManager == null)
         {
             Debug.LogError("해당 스테이지에 GameManager가 할당되지 않아 정상적인 게임 로직 실행 불가능");
             return;
         }
-
-        // 생존 중인 플레이어가 없거나 리스트가 비어 있으면, 스테이지 실행을 중지하고 메시지 출력
-        /*if (alivePlayers == null || alivePlayers.Count == 0)
-        {
-            Debug.LogWarning("현재 스테이지 안에 있는 플레이어를 찾을 수 없습니다.");
-            return;
-        }*/
 
         // 스테이지 타임이 0 이하일 경우, 유효하지 않은 값이므로 종료
         if (stageTime <= 0)
@@ -54,9 +60,7 @@ public class StageManager : NetworkBehaviour
         // 스테이지 타이머 및 로직을 실행하는 함수 호출
         StartLogicTimer();
     }
-    #endregion
 
-    #region Stage Logic
     /// <summary>
     /// 스테이지 타이머와 로직을 시작하는 메서드
     /// </summary>
@@ -75,6 +79,10 @@ public class StageManager : NetworkBehaviour
     /// <returns></returns>
     IEnumerator StageLogicCoroutine()
     {
+        // 스테이지 생존 플레이어 리스트 세팅
+        for (int i = 0; i < gameManager.playerCharacters.Count; i++)
+            alivePlayers.Add(gameManager.playerCharacters[i]);
+
         Debug.Log($"[게임 타이머 시작!!] / {gameObject.name}"); // 타이머 시작 메시지 출력
         float count = 0;    // 타이머 카운트 변수 (초 단위로 진행)
         IsFinished = false;
@@ -83,13 +91,13 @@ public class StageManager : NetworkBehaviour
         while (count < stageTime)
         {
             // 스테이지에 단 한 명의 플레이어만 남았다면, 스테이지 종료
-            if (alivePlayers.Count == 1)
+            /*if (alivePlayers.Count == 1)
             {
                 Debug.Log("최후의 플레이어 탄생! 게임 스테이지를 종료합니다~");
                 stageLogic = null;
                 IsFinished = true;
                 yield break;
-            }
+            }*/
             Debug.Log($"현재 스테이지 종료까지 남은 시간 : {stageTime - count}");   // 남은 시간 출력
             count += 1; // 타이머 카운트 1 증가
             // 타이머 1초씩 증가
@@ -104,8 +112,20 @@ public class StageManager : NetworkBehaviour
         Debug.Log("[타임 종료~~]");
         IsFinished = true;
         stageLogic = null;
+        alivePlayers.Clear();   // 생존 플레이어 리스트 초기화
 
         gameManager.ProcessStageCompletion();
     }
+
+    /// <summary>
+    /// 스테이지 보이는 오브젝트 활성화/비활성화 관리
+    /// </summary>
+    /// <param name="isActive">활성화 여부</param>
+    public void ActivateStage(bool isActive)
+    {
+        stageVisualRoot.SetActive(isActive); // 시각적으로만 On/Off
+        enabled = isActive; // MonoBehaviour 로직도 On/Off
+    }
     #endregion
+
 }

--- a/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
+++ b/Assets/Workspace/Lee_yerin/Scripts/StageManager.cs
@@ -26,7 +26,8 @@ public class StageManager : NetworkBehaviour
 
     [Header("Players")]
     [Tooltip("현재 스테이지에서 생존 중인 플레이어들 보관하는 List")]
-    [SerializeField] List<NetworkObject> alivePlayers;
+    [SerializeField] List<Character> alivePlayers;
+    public List<Character> AlivePlayers => alivePlayers;
 
     [Tooltip("플레이어들 스폰 위치 List")]
     [SerializeField] List<Transform> playersSpawnPoints;
@@ -79,9 +80,15 @@ public class StageManager : NetworkBehaviour
     /// <returns></returns>
     IEnumerator StageLogicCoroutine()
     {
+        yield return null;  // 한 프레임 기다리기 (클라이언트의 gameManager.playerCharacters 세팅 기다리기)
+
         // 스테이지 생존 플레이어 리스트 세팅
         for (int i = 0; i < gameManager.playerCharacters.Count; i++)
-            alivePlayers.Add(gameManager.playerCharacters[i]);
+        {
+            alivePlayers.Add(gameManager.playerCharacters[i].GetComponent<Character>());
+
+            alivePlayers[i].currentStage = this;
+        }
 
         Debug.Log($"[게임 타이머 시작!!] / {gameObject.name}"); // 타이머 시작 메시지 출력
         float count = 0;    // 타이머 카운트 변수 (초 단위로 진행)
@@ -91,23 +98,21 @@ public class StageManager : NetworkBehaviour
         while (count < stageTime)
         {
             // 스테이지에 단 한 명의 플레이어만 남았다면, 스테이지 종료
-            /*if (alivePlayers.Count == 1)
+            if (alivePlayers.Count == 1)
             {
                 Debug.Log("최후의 플레이어 탄생! 게임 스테이지를 종료합니다~");
                 stageLogic = null;
                 IsFinished = true;
+                alivePlayers.Clear();
+                gameManager.ProcessStageCompletion();
                 yield break;
-            }*/
+            }
             Debug.Log($"현재 스테이지 종료까지 남은 시간 : {stageTime - count}");   // 남은 시간 출력
             count += 1; // 타이머 카운트 1 증가
             // 타이머 1초씩 증가
             yield return new WaitForSecondsRealtime(1f);
         }
 
-        foreach (var player in alivePlayers)
-        {
-            Destroy(player);
-        }
         // 타이머 종료 시 메시지 출력
         Debug.Log("[타임 종료~~]");
         IsFinished = true;

--- a/Assets/Workspace/Seo_juwon/Prefab/Player1 1.prefab
+++ b/Assets/Workspace/Seo_juwon/Prefab/Player1 1.prefab
@@ -217,6 +217,7 @@ MonoBehaviour:
   NestedObjects: []
   NetworkedBehaviours:
   - {fileID: 862801129570647655}
+  - {fileID: 5699380459216588828}
   ForceRemoteRenderTimeframe: 0
 --- !u!54 &4522118908284164683
 Rigidbody:

--- a/Assets/Workspace/Seo_juwon/Scripts/Character.cs
+++ b/Assets/Workspace/Seo_juwon/Scripts/Character.cs
@@ -1,6 +1,7 @@
+using Fusion;
 using UnityEngine;
 
-public class Character : MonoBehaviour
+public class Character : NetworkBehaviour
 {
     public string characterName;
     public Animator animator; //공격 모션
@@ -14,6 +15,8 @@ public class Character : MonoBehaviour
     private bool isUsingSkill = false;
     public Skill skill;
     public Transform firePoint;
+
+    public StageManager currentStage;
 
     private void Start()
     {
@@ -40,6 +43,7 @@ public class Character : MonoBehaviour
         Debug.Log($"{characterName} 사망");
         //죽으면 오브젝트 사라짐
         gameObject.SetActive(false);
+        currentStage.AlivePlayers.Remove(this); // 플레이어 사망 시 스테이지 생존자 리스트에서 삭제
     }
     //맵 아래로 떨어졌을 때
     private void Update()

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,9 +140,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 1.0.2
-  preloadedAssets:
-  - {fileID: -1937939028782796339, guid: 9e40c89fa255262459b9b75ff01a81cc, type: 2}
-  - {fileID: 11400000, guid: 6d90253c626bbb341866266173746b0f, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,9 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 1.0.2
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: -1937939028782796339, guid: 9e40c89fa255262459b9b75ff01a81cc, type: 2}
+  - {fileID: 11400000, guid: 6d90253c626bbb341866266173746b0f, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
- 게임 및 스테이지 로직 관련 리스트를 서버/클라이언트에서 모두 일관되게 관리하기 위해,
  클라이언트에서는 `TryGetPlayerObject()` 기반으로 재구성하도록 변경
- 각 스테이지마다 플레어의 기존 캐릭터는 삭제, 새로운 캐릭터 각 위치로 스폰
- Fusion의 동기화 지연 문제를 고려하여, 해당 로직을 Coroutine으로 한 프레임 이상 지연 처리
- 플레이어 사망 시 현재 진행 중인 스테이지의 StageManager의 생존자 리스트에서 삭제되게 함.